### PR TITLE
chore: refactor

### DIFF
--- a/src/routers/services.ts
+++ b/src/routers/services.ts
@@ -3,18 +3,10 @@ import servicesService from '../services/services';
 
 const servicesRouter = express.Router();
 
-// will get all services
+// will get all services - assumes one pipeline
 servicesRouter.get('/', async (req: Request, res: Response) => {
   const servicesData = await servicesService.getAll();
   res.status(200).json(servicesData);
-});
-
-// will get all services for a pipeline
-// if multiple pipelines this can be useful displaying all the services that belong to one pipeline
-servicesRouter.get('/:pipelineID', async (req: Request, res: Response) => {
-  const { pipelineID } = req.params;
-  const serviceData = await servicesService.getAllForPipeline(pipelineID);
-  res.status(200).json(serviceData);
 });
 
 export default servicesRouter;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,6 +1,6 @@
 import prisma from './prismaClient';
 
-// gets all services - only top level data
+// gets all services - only top level data - assumes one pipeline
 async function getAll() {
   try {
     const allServices = await prisma.service.findMany();
@@ -12,21 +12,4 @@ async function getAll() {
   }
 }
 
-// will get all services for a pipeline
-// if multiple pipelines this can be useful displaying all the services that belong to one pipeline
-async function getAllForPipeline(pipelineId: string) {
-  try {
-    const allServices = await prisma.service.findMany({
-      where: {
-        pipelineId: pipelineId
-      }
-    });
-    await prisma.$disconnect();
-    return allServices;
-  } catch (e) {
-    console.error(e);
-    await prisma.$disconnect();
-  }
-}
-
-export default { getAll, getAllForPipeline };
+export default { getAll };


### PR DESCRIPTION
- refactor to remove a services router since db schema changed
- previously you could get services by querying for pipelineId and you would get all services for that pipeline id
- currently assumming only one pipeline so that isn't necessary
- may be needed in the future and can adapt
- this has been changed to keep the front end RESTful and to build a basic app first and later add complexity