### PR TITLE
feat: pre create stages

### DIFF
--- a/src/routers/runs.ts
+++ b/src/routers/runs.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import runsService from '../services/runs';
+import stagesService from '../services/stages';
 
 const runsRouter = express.Router();
 
@@ -16,16 +17,16 @@ runsRouter.get('/:runId', async (req: Request, res: Response) => {
 });
 
 // post to runs router when run button is clicked on a service
+// this will create an empty run and corresponding empty stages for use since
+// a run has stages
 runsRouter.post('', async (req: Request, res: Response) => {
   const { serviceId } = req.query;
 
-  // create a new run in db
+  // create a new empty run in db
   const newRun: any = await runsService.createOne(serviceId);
-  console.log(newRun.id);
 
-
-  // create a new stages data in the db using the newRun id
-
+  // create new empty stages data in the db using the newRun id
+  await stagesService.createAll(newRun.id);
 
   res.status(200).json(newRun);
 });

--- a/src/services/runs.ts
+++ b/src/services/runs.ts
@@ -33,9 +33,7 @@ async function getOne(runId: string) {
 }
 
 
-// method to create a run - will be used to create empty run & stages
-// this is for state machine to use
-// serviceId has to already exist in service table to satisfy foreign key constraint
+// method to create a run - will be used to create empty run 
 async function createOne(serviceId: any) {
   try {
     const run = await prisma.run.create({
@@ -45,9 +43,6 @@ async function createOne(serviceId: any) {
         serviceId: serviceId,
       }
     });
-
-    // now add stages that are linked to this run
-
     await prisma.$disconnect();
     return run;
   } catch (e) {

--- a/src/services/stages.ts
+++ b/src/services/stages.ts
@@ -1,6 +1,6 @@
 import prisma from './prismaClient';
+import { StageType } from '@prisma/client';
 
-// runs are displayed for a particular service - all runs are not displayed  in a literal sense. only runs for a service are displayed
 async function getAllForRun(runId: any) {
   try {
     const allStages = await prisma.stage.findMany({
@@ -16,4 +16,139 @@ async function getAllForRun(runId: any) {
   }
 }
 
-export default { getAllForRun };
+async function createAll(runId: any) {
+  try {
+    await Promise.all([
+      createPrepare(runId),
+      createCodeQuality(runId),
+      createUnitTest(runId),
+      createIntegrationTest(runId),
+      createBuild(runId),
+      createDeployStaging(runId),
+      createDeployProd(runId),
+    ]);
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+async function createPrepare(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.PREPARE,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+async function createCodeQuality(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.CODE_QUALITY,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+async function createUnitTest(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.UNIT_TEST,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+async function createIntegrationTest(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.INTEGRATION_TEST,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+async function createBuild(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.BUILD,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+async function createDeployStaging(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.DEPLOY_STAGING,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+async function createDeployProd(runId: any) {  
+  try {
+    const stage = await prisma.stage.create({
+      data: {
+        startedAt: new Date(),
+        type: StageType.DEPLOY_PROD,
+        runId: runId,
+      }
+    });
+    await prisma.$disconnect();
+    return stage;
+  } catch (e) {
+    console.error(e);
+    await prisma.$disconnect();
+  }  
+}
+
+export default { getAllForRun, createAll };


### PR DESCRIPTION
- when a run is created stages will also be created
- this is for an empty run and empty stages for use by state machine
- when user clicks the run button this action will occur so the run and stages are set up
- can refactor to make cleaner code