### PR TITLE
feat: complete sfn trigger logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,21 @@
 PORT=3000
-DATABASE_URL='my-sql-database-url'
+
+DATABASE_URL="postgresql://user:password@abc.def.us-east-1.rds.amazonaws.com:5432/tableName?schema=public"
+REDIS_HOST="rediscluster.abc.de.0001.use1.cache.amazonaws.com"
+REDIS_PORT=6379
+
+# For Lambdas
+API_KEY=7b9db2d1-f83d-45c8-9874-fa86e4b578e0
+GET_LAMBDA=https://abc123.lambda-url.us-east-1.on.aws
+SET_LAMBDA=https://def234.lambda-url.us-east-1.on.aws
+
+AWS_ACCOUNT_ID=123456789012
+AWS_ACCESS_KEY=ABCDEFGHIJKLMNOPQRST
+AWS_SECRET_ACCESS_KEY=abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+
+GITHUB_PAT=ghp_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv
+GITHUB_REPO_URL=https://github.com/username/repo
+
+AWS_STEP_FUNCTION_ARN=arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine123ABC-ABC123
+
+LOG_SUBSCRIBER_URL=https://abc123.m.pipedream.net

--- a/prisma/migrations/20230310030421_make_default_run_status_idle/migration.sql
+++ b/prisma/migrations/20230310030421_make_default_run_status_idle/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Run" ALTER COLUMN "status" SET DEFAULT 'IDLE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,9 +7,9 @@ generator client {
   provider = "prisma-client-js"
 }
 
-generator zod {
-  provider = "prisma-zod-generator"
-}
+// generator zod {
+//   provider = "prisma-zod-generator"
+// }
 
 datasource db {
   provider = "postgresql"

--- a/prisma/seed_data/seed_envvars.ts
+++ b/prisma/seed_data/seed_envvars.ts
@@ -1,3 +1,6 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 import { ResourceType } from '@prisma/client';
 import prisma from '../../src/clients/prisma-client';
 
@@ -6,38 +9,46 @@ export const seedPipelineEnvironmentVariables = async (pipelineId: string) => {
     data: [
       {
         resourceType: ResourceType.PIPELINE,
+        resourceId: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e1',
         name: 'awsRegion',
         value: 'us-east-1',
       },
       {
         resourceType: ResourceType.PIPELINE,
+        resourceId: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e1',
         name: 'awsAvailabilityZone',
         value: 'us-east-1a',
       },
       {
         resourceType: ResourceType.PIPELINE,
+        resourceId: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e1',
         name: 'awsAccountId',
-        value: '12345789012',
+        value: process.env.AWS_ACCOUNT_ID || '',
       },
       {
         resourceType: ResourceType.PIPELINE,
         name: 'awsEcsCluster',
-        value: 'my_ecs_cluster',
+        value: 'demo-cluster',
+      },
+      {
+        resourceType: ResourceType.PIPELINE,
+        name: 'awsEcsClusterStaging',
+        value: 'demo-cluster',
       },
       {
         resourceType: ResourceType.PIPELINE,
         name: 'awsStepFunction',
-        value: 'my_stepfunction',
+        value: process.env.AWS_STEP_FUNCTION_ARN || '',
       },
       {
         resourceType: ResourceType.PIPELINE,
         name: 'awsRds',
-        value: 'my_rds_connection_string',
+        value: process.env.DATABASE_URL || '',
       },
       {
         resourceType: ResourceType.PIPELINE,
         name: 'awsElastiCache',
-        value: 'my_elasticache_endpoint',
+        value: process.env.REDIS_HOST || '',
       },
     ].map((envVarData) => ({
       ...envVarData,
@@ -54,27 +65,32 @@ export const seedServiceEnvironmentVariables = async (serviceId: string) => {
       {
         resourceType: ResourceType.SERVICE,
         name: 'awsEcsService',
-        value: 'my_ecs_service',
+        value: 'seamless-demo-notification',
+      },
+      {
+        resourceType: ResourceType.SERVICE,
+        name: 'awsEcsServiceStaging',
+        value: 'seamless-demo-notification',
       },
       {
         resourceType: ResourceType.SERVICE,
         name: 'awsEcsTaskDefinition',
-        value: 'my_task_definition',
+        value: 'seamless-demo-notification',
       },
       {
         resourceType: ResourceType.SERVICE,
         name: 'awsEcrRepository',
-        value: 'my_ecr_repository',
+        value: 'seamless-demo-notification',
       },
       {
         resourceType: ResourceType.SERVICE,
         name: 'awsSnsTopic',
-        value: 'my_sns_topic',
+        value: 'seamless-pipeline-topic',
       },
       {
         resourceType: ResourceType.SERVICE,
         name: 'logSubscriberUrl',
-        value: 'my_logging_service_url',
+        value: process.env.LOG_SUBSCRIBER_URL || '',
       },
       {
         resourceType: ResourceType.SERVICE,

--- a/prisma/seed_data/seed_pipelines.ts
+++ b/prisma/seed_data/seed_pipelines.ts
@@ -1,97 +1,64 @@
-import { Status, TriggerType, StageType } from '@prisma/client';
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { TriggerType, StageType } from '@prisma/client';
 import prisma from '../../src/clients/prisma-client';
 
 export const seedPipelines = async () => {
   await prisma.pipeline.create({
     data: {
-      name: 'Pipeline 01',
-      githubPat: 'my_github_pat',
-      awsAccessKey: 'my_aws_access_key',
-      awsSecretAccessKey: 'my_aws_secret_access_key',
+      id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e1',
+      name: 'Demo Pipeline',
+      githubPat: process.env.GITHUB_PAT || '',
+      awsAccessKey: process.env.AWS_ACCESS_KEY || '',
+      awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
       services: {
         create: [
           {
-            name: 'Service01',
+            id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e2',
+            name: 'Demo Service',
             triggerOnMain: true,
-            triggerOnPrOpen: true,
-            triggerOnPrSync: true,
+            triggerOnPrOpen: false,
+            triggerOnPrSync: false,
             useStaging: false,
-            githubRepoUrl: 'my_github_repository',
+            autoDeploy: false,
+            githubRepoUrl: process.env.GITHUB_REPO_URL || '',
             unitTestCommand: 'npm run test',
             codeQualityCommand: 'npm run lint',
             dockerfilePath: '.',
             runs: {
               create: [
-                // Most stages idle
                 {
-                  startedAt: '2022-02-28T11:00:00.000Z',
-                  commitHash: 'abc234',
-                  commitMessage: 'My commit message',
+                  id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e3',
+                  commitHash: 'abc123',
+                  commitMessage: 'feat: add notification feature',
                   committer: 'Jason Wang',
                   triggerType: TriggerType.MAIN,
                   stages: {
                     create: [
                       {
+                        id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e4',
                         type: StageType.PREPARE,
-                        startedAt: '2022-02-28T11:00:00.000Z',
-                        status: Status.IDLE,
                       },
                       {
+                        id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e5',
                         type: StageType.CODE_QUALITY,
-                        startedAt: '2022-02-28T11:01:00.000Z',
-                        status: Status.IDLE,
                       },
                       {
+                        id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e6',
                         type: StageType.UNIT_TEST,
-                        startedAt: '2022-02-28T11:02:00.000Z',
-                        status: Status.IDLE,
                       },
                       {
+                        id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e7',
                         type: StageType.BUILD,
-                        startedAt: '2022-02-28T11:03:00.000Z',
-                        status: Status.IDLE,
                       },
                       {
+                        id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e8',
+                        type: StageType.DEPLOY_STAGING,
+                      },
+                      {
+                        id: 'd8583d1c-ce63-4e0c-bd55-2088409bc7e9',
                         type: StageType.DEPLOY_PROD,
-                        startedAt: '2022-02-28T11:04:00.000Z',
-                        status: Status.IDLE,
-                      },
-                    ],
-                  },
-                },
-                // Failure
-                {
-                  startedAt: '2022-02-28T10:00:00.000Z',
-                  commitHash: 'abc123',
-                  commitMessage: 'My commit message',
-                  committer: 'Jason Wang',
-                  triggerType: TriggerType.PR_OPEN,
-                  stages: {
-                    create: [
-                      {
-                        type: StageType.PREPARE,
-                        startedAt: '2022-02-28T10:00:00.000Z',
-                        status: Status.SUCCESS,
-                      },
-                      {
-                        type: StageType.CODE_QUALITY,
-                        startedAt: '2022-02-28T10:01:00.000Z',
-                        status: Status.SUCCESS,
-                      },
-                      {
-                        type: StageType.UNIT_TEST,
-                        startedAt: '2022-02-28T10:02:00.000Z',
-                        status: Status.FAILURE,
-                      },
-                      {
-                        type: StageType.BUILD,
-                        startedAt: '2022-02-28T10:00:00.000Z',
-                        status: Status.IDLE,
-                      },
-                      {
-                        type: StageType.DEPLOY_PROD,
-                        startedAt: '2022-02-28T10:00:00.000Z',
-                        status: Status.IDLE,
                       },
                     ],
                   },

--- a/src/clients/step-function/input.example.json
+++ b/src/clients/step-function/input.example.json
@@ -42,7 +42,7 @@
     }
   },
   "runFull": "true",
-  "useStaging": "true",
+  "useStaging": "false",
   "autoDeploy": "false",
   "containerVariables": {
     "awsRegion": "us-east-1",

--- a/src/routers/public/runs.ts
+++ b/src/routers/public/runs.ts
@@ -42,8 +42,8 @@ runsRouter.post('/', async (req: Request, res: Response) => {
 runsRouter.post('/:runId/start', async (req: Request, res: Response) => {
   const { runId } = req.params;
   try {
-    await stepFunctionsService.start(runId);
-    res.status(200).json({ message: 'Step function started' });
+    const response = await stepFunctionsService.start(runId);
+    res.status(200).json(response);
   } catch (error) {
     res
       .status(500)

--- a/src/schemas/step-functions-schema.ts
+++ b/src/schemas/step-functions-schema.ts
@@ -53,6 +53,8 @@ const ContainerVariablesSchema = z.object({
   codeQualityCommand: z.string().optional(),
   unitTestCommand: z.string().optional(),
   dockerfilePath: z.string(),
+  awsEcsClusterStaging: z.string(),
+  awsEcsServiceStaging: z.string(),
   awsEcsCluster: z.string(),
   awsEcsService: z.string(),
   awsEcrRepo: z.string(),
@@ -69,6 +71,7 @@ const SfnInputSchema = z.object({
   stageIds: StageIdsSchema,
   runStatus: RunStatusSchema,
   runFull: z.boolean(),
+  useStaging: z.boolean(),
   autoDeploy: z.boolean(),
   containerVariables: ContainerVariablesSchema,
 });

--- a/src/services/pipelines.ts
+++ b/src/services/pipelines.ts
@@ -6,6 +6,7 @@ export interface PipelineWithEnvVars extends Pipeline {
   awsRegion: string;
   awsAvailabilityZone?: string;
   awsAccountId: string;
+  awsEcsClusterStaging?: string;
   awsEcsCluster: string;
   awsStepFunction: string;
   awsRds: string;

--- a/src/services/runs.ts
+++ b/src/services/runs.ts
@@ -1,6 +1,5 @@
 import prisma from '../clients/prisma-client';
 import { TriggerType } from '@prisma/client';
-import { pipelineStatusUpdateSchema } from '../schemas';
 
 // runs are displayed for a particular service - all runs are not displayed  in a literal sense. only runs for a service are displayed
 async function getAllForService(serviceId: any) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3,6 +3,7 @@ import { ResourceType, EnvironmentVariable, Service } from '@prisma/client';
 import envVarsService from './envVars';
 
 export interface ServiceWithEnvVars extends Service {
+  awsEcsServiceStaging?: string;
   awsEcsService?: string;
   awsEcsTaskDefinition?: string;
   awsEcrRepository?: string;


### PR DESCRIPTION
Add route `runsRouter.post('/:runId/start'` to initiate a pipeline run for a specific Run. Records for the Run and the Stages must already have been created in the database.